### PR TITLE
Fix typo in BaseExecutor.sol documentation comment

### DIFF
--- a/contracts/V2/Executors/BaseExecutor.sol
+++ b/contracts/V2/Executors/BaseExecutor.sol
@@ -75,7 +75,7 @@ abstract contract BaseExecutor is OwnableUpgradeable, ReentrancyGuardUpgradeable
 
     /**
      * @notice Collects the integrator fee from a trade and updates the Unizen fee earned
-     * send fee directy to integrator
+     * send fee directly to integrator
      * @param isETHTrade Indicates if the trade involves ETH
      * @param token The token involved in the trade
      * @param feeReceiver Address to receive the fee of Integrator


### PR DESCRIPTION


**Description:**  
This pull request corrects a minor typo in the documentation comment of the `BaseExecutor.sol` contract. The word "directy" has been changed to "directly" in the line describing the fee sending process to the integrator. No functional code changes were made; this update is purely for documentation clarity and accuracy.
